### PR TITLE
urllib3 version update and werkzeug fallback to 2.3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask-Login==0.6.2
 google-auth==2.21.0
 requests==2.31.0
-urllib3==1.26.0
+urllib3==1.26.17
+werkzeug==2.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 Flask-Login==0.6.2
 google-auth==2.21.0
 requests==2.31.0
-urllib3==1.26.17
-werkzeug==2.3.7
+urllib3>=1.26,<2
+requests>=2.30.0
+wheel>=0.34.2
+werkzeug<3


### PR DESCRIPTION
urllib3 update
werkzeug fallback to 2.3.7 (3.0.0 gives the url_encode errors)