### PR TITLE
Add Timer trait

### DIFF
--- a/modules/domoticz.py
+++ b/modules/domoticz.py
@@ -127,8 +127,6 @@ def getAog(device, user_id=None):
         aog.type = 'action.devices.types.SWITCH'
     if domain in ['DoorLock', 'DoorLockInverted']:
         aog.type = 'action.devices.types.LOCK'
-    if domain in ['OnOff', 'Dimmer', 'ColorSwitch']:
-        aog.traits.append('action.devices.traits.Timer')
     
     aog.customData['check_state'] = True
     # Try to get device specific voice control configuration from Domoticz
@@ -352,6 +350,11 @@ def getAog(device, user_id=None):
             ],
             'cameraStreamNeedAuthToken': False
         }
+        
+    if domain in ['OnOff', 'Dimmer', 'ColorSwitch']:
+        aog.traits.append('action.devices.traits.Timer')
+        aog.attributes['maxTimerLimitSec'] = 7200
+        aog.attributes['commandOnlyTimer'] = True
     
     batteryLevel = device.get('BatteryLevel')
     if domain not in ['Group', 'Scene'] and batteryLevel != 255:

--- a/modules/domoticz.py
+++ b/modules/domoticz.py
@@ -127,6 +127,8 @@ def getAog(device, user_id=None):
         aog.type = 'action.devices.types.SWITCH'
     if domain in ['DoorLock', 'DoorLockInverted']:
         aog.type = 'action.devices.types.LOCK'
+    if domain in ['OnOff', 'Dimmer', 'ColorSwitch']:
+        aog.traits.append('action.devices.traits.Timer')
     
     aog.customData['check_state'] = True
     # Try to get device specific voice control configuration from Domoticz
@@ -181,7 +183,7 @@ def getAog(device, user_id=None):
     aog.customData['idx'] = device.get('idx')
     aog.customData['domain'] = domain
     aog.customData['protected'] = device.get('Protected')
-    aog.notificationSupportedByAgent = (True if domain in ['SmokeDetector', 'Doorbell', 'DoorLock', 'DoorLockInverted'] else False)       
+    aog.notificationSupportedByAgent = (True if domain in ['SmokeDetector', 'Doorbell', 'DoorLock', 'DoorLockInverted'] else False)
 
     if domain == 'Scene':
         aog.type = 'action.devices.types.SCENE'
@@ -425,3 +427,16 @@ def getDomoticzState(user_id, idx, device='id'):
         data = d
 
     return data
+
+
+def getDzUser(user_id):
+
+    url = "?type=command&param=getusers"
+    try:
+        r = json.loads(queryDomoticz(user_id, url))
+        if r['status'] == 'OK':
+            return True
+        else:
+            return False
+    except Exception as err:
+        return False

--- a/modules/routes.py
+++ b/modules/routes.py
@@ -9,7 +9,7 @@ from werkzeug.utils import secure_filename
 from werkzeug.security import generate_password_hash, check_password_hash
 from modules.reportstate import ReportState
 from modules.database import db, User, Settings
-from modules.domoticz import saveJson, getDomoticzDevices
+from modules.domoticz import saveJson, getDomoticzDevices, getDzUser
 from modules.helpers import logger, get_devices, generateToken, remove_user, getVersion
 from sqlalchemy import or_
 
@@ -44,6 +44,7 @@ def devices():
     devices = get_devices(current_user.username)
     dbuser = User.query.filter_by(username=current_user.username).first()
     version = getVersion()
+    dzUserAdmin = getDzUser(current_user.username)
 
     if request.method == "POST":
 
@@ -180,7 +181,8 @@ def devices():
                                reportstate=reportstate,
                                devices=devices,
                                _csrf_token=session['_csrf_token'],
-                               version = version
+                               version = version,
+                               dzUserAdmin = dzUserAdmin
                                )
 
 
@@ -302,6 +304,7 @@ def settings():
         reportstate = report_state.report_state_enabled()
         devices = get_devices(current_user.username)
         version = getVersion()
+        dzUserAdmin = getDzUser(current_user.username)
 
         return render_template('settings.html',
                                user=User.query.filter_by(username=current_user.username).first(),
@@ -310,7 +313,8 @@ def settings():
                                reportstate=reportstate,
                                devices=devices,
                                _csrf_token=session['_csrf_token'],
-                               version = version
+                               version = version,
+                               dzUserAdmin = dzUserAdmin
                                )
 
 

--- a/modules/trait.py
+++ b/modules/trait.py
@@ -327,8 +327,8 @@ def execute(device, command, params, user_id, challenge):
                     url += "setsecstatus&secstatus=2"
         else:
             if state['Data'] == "Normal" and check_state:
-                raise SmartHomeError('alreadyInState',
-                                   'Unable to execute {} for {}. Already in state '.format(command, device['id']))
+                raise SmartHomeError('alreadyDisarmed',
+                                   'Unable to execute {} for {}. Already disarmed '.format(command, device['id']))
             else:
                 url += "setsecstatus&secstatus=0"
 
@@ -348,6 +348,14 @@ def execute(device, command, params, user_id, challenge):
                 slevel = str(levelName.index(key) * 10)
 
             url += 'switchlight&idx=' + idx + '&switchcmd=Set%20Level&level=' + slevel
+            
+    if command == 'action.devices.commands.TimerStart':
+    
+        url = 'customevent&event=TIMER&data={"idx":' + idx + ',"time":' + str(params['timerTimeSec']) + ',"on":true}'
+        
+    if command == 'action.devices.commands.TimerCancel':
+
+        url = 'customevent&event=TIMER&data={"idx":' + idx + ',"cancel":true}'
 
     if state['Protected'] is True:
         url = url + '&passcode=' + challenge.get('pin')

--- a/modules/trait.py
+++ b/modules/trait.py
@@ -351,11 +351,11 @@ def execute(device, command, params, user_id, challenge):
             
     if command == 'action.devices.commands.TimerStart':
     
-        url = 'customevent&event=TIMER&data={"idx":' + idx + ',"time":' + str(params['timerTimeSec']) + ',"on":true}'
+        url += 'customevent&event=TIMER&data={"idx":' + idx + ',"time":' + str(params['timerTimeSec']) + ',"on":true}'
         
     if command == 'action.devices.commands.TimerCancel':
 
-        url = 'customevent&event=TIMER&data={"idx":' + idx + ',"cancel":true}'
+        url += 'customevent&event=TIMER&data={"idx":' + idx + ',"cancel":true}'
 
     if state['Protected'] is True:
         url = url + '&passcode=' + challenge.get('pin')

--- a/static/js/smarthome.js
+++ b/static/js/smarthome.js
@@ -365,17 +365,6 @@ function setSelectorLevel(div, idx, protect) {
 	requestAPI(requesturl)
 }
 
-function getUser(user) {
-	var url = "/api?type=command&param=getusers"
-	requestAPI(url).then(jsonData => {
-		var data = jsonData
-		if (data.status == 'ERR' || data.status == null) {
-			$('#domoticzAdmin').val('No')
-		} else {
-			$('#domoticzAdmin').val('Yes')
-		}			
-	});
-}
 function getDzVersion() {
 	var url = "/api?type=command&param=getversion"
 	requestAPI(url).then(jsonData => {

--- a/templates/devices.html
+++ b/templates/devices.html
@@ -96,12 +96,12 @@
 										<div class="form-check form-switch">
 										  <input class="form-check-input" type="checkbox" id="checkState" name="checkState" {% if v['customData']['check_state'] == True %}checked{% endif %}>
 										  <label class="form-check-label" for="checkState">Check State</label></br>
-										  <small class="form-text">Turns on/off already in state error message</small>
+										  <small class="form-text">Turns on/off 'already in state' error message</small>
 										</div>
 										<div class="form-check form-switch">
 										  <input class="form-check-input" type="checkbox" id="notification" name="notification" {% if v['notificationSupportedByAgent'] == True %}checked {% endif %} disabled>
-										  <label class="form-check-label" for="notification">Notification Supported</label></br>
-										  {% if v['notificationSupportedByAgent'] == True %}<small class="form-text">User can turn on or off notifications in Google Home App</small>{% endif %}
+										  <label class="form-check-label" for="notification">Support Notification</label></br>
+										  {% if v['notificationSupportedByAgent'] == True %}<small class="form-text">User can turn on/off notifications in Google Home App</small>{% endif %}
 										</div>
 										<div class="form-check form-switch">
 										  <input class="form-check-input" type="checkbox" id="secondaryUserVerificationCheck_{{ v['id'] }}" {% if ('acknowledge' in v['customData'] or v['customData']['protected'] == True) %}checked{% endif %}{% if 'Hidden' in v['customData']['domain'] %} disabled{% endif %}>
@@ -118,10 +118,10 @@
 											  </label>
 											</div>
 											<div class="form-check">
-											  <input class="form-check-input" type="radio" name="2FA" id="pinNeeded" value="pinNeeded" {% if v['customData']['protected'] == True %}checked{% endif %}{% if ('Hidden' in v['customData']['domain'] or v['customData']['protected'] != True) %} disabled{% endif %}>
+											  <input class="form-check-input" type="radio" name="2FA" id="pinNeeded" value="pinNeeded" {% if v['customData']['protected'] == True %}checked{% endif %}{% if dzUserAdmin is not true %} disabled{% endif %}>
 											  <label class="form-check-label" for="pinNeeded">
 												Pincode Needed 
-											  </label> <small>(Set device as protected in Domoticz)</small>
+											  </label>{% if dzUserAdmin is not true %} <small class="form-text">(Set device as protected in Domoticz)</small>{% endif %}
 											</div>
 										  </div>
 										</fieldset>
@@ -319,9 +319,9 @@
 							  </div><!-- End Vertically centered Modal-->
                         <td>
 						{% if v['customData']['protected'] == False %}
-							<button class="btn btn-outline-success btn-sm" onclick="toogleProtected({{ v['customData']['idx'] }}, 'true')" {% if not user.admin %}disabled{% endif %}>No
+							<button class="btn btn-outline-success btn-sm" onclick="toogleProtected({{ v['customData']['idx'] }}, 'true')" title="Domoticz Admin user can turn protection on/off here"{% if dzUserAdmin is not true %} disabled{% endif %}>No
 							{% else %}
-							<button class="btn btn-outline-danger btn-sm" onclick="toogleProtected({{ v['customData']['idx'] }}, 'false')" {% if not user.admin %}disabled{% endif %}>Yes
+							<button class="btn btn-outline-danger btn-sm" onclick="toogleProtected({{ v['customData']['idx'] }}, 'false')" title="Domoticz Admin user can turn protection on/off here"{% if dzUserAdmin is not true %} disabled{% endif %}>Yes
 						{% endif %}							
 						</button></td>
 						<td><button class="btn btn-light btn-sm" id="switch_{{ v['customData']['idx'] }}" disabled>Not available</button></td>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -73,7 +73,7 @@
 						</div>
 						<div class="col-md-6" >
 						  <label for="domoticzAdmin" class="form-label">Domoticz Admin</label>
-						  <input type="text" class="form-control" id="domoticzAdmin" value="No" disabled readonly>
+						  <input type="text" class="form-control" id="domoticzAdmin" value="{% if dzUserAdmin is true %}Yes{% else %}No{% endif %}" disabled readonly>
 						</div>
 						<div class="col-md-12" id="div_token">
 						  <label for="token" class="form-label">Auth Token</label>
@@ -125,7 +125,5 @@ $(".togglePassword").click(function (e) {
 	  $(this).parent().parent().find(".password").attr("type","password");
 	}
 });
-
-getUser("{{ user.domouser }}")
 
   </script>


### PR DESCRIPTION
Needs to add a dzVents script in Domoticz to act like a timer. Example:

```lua
return {
	on = {
            customEvents = { 'TIMER' },
	},
	logging = {
            level = domoticz.LOG_INFO,
            marker = "Timer"
        },
	execute = function(dzga, item)
	    if (item.isJSON) then
    	        local device = dzga.devices(item.json.idx)
    	    
    	    if (device.active and item.json.cancel) then
    	        dzga.log('Stop timer for ' .. device.name)
    	        device.cancelQueuedCommands()
            else
                dzga.log('No timer is running for' .. device.name)
            end
            if  item.json.on == true then
                device.cancelQueuedCommands()
                device.switchOn()
                dzga.log('Switch ' .. device.name .. ' On for: ' .. item.json.time .. ' sec')
                device.switchOff().afterSec(item.json.time)
            end
        end
    end
}
```
Use like this:
>**User:** Turn on living room light for 5 minutes.  
>**Google Assistant:** Turning on living room light for 5 minutes?  
>**User:** Stop timer for living room light.  
>**Google Assistant:** Updating living room timer? (Turn off light/switch manually)